### PR TITLE
Update setup code to match code and fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ make flash
 
 # Setup Code
 While pairing accessory and iOS devices, You must enter Setup Code at HOME App.
-The default setupt code is 
-## **`053-58-917`**
+The default setup code is 
+## **`053-58-197`**
 
 


### PR DESCRIPTION
The setup code described in readme.md did not match the implementation in main.c. I updated readme.md to match the implementation and fixed a small typo while I was at it.