### PR TITLE
Improper use of strlen causes pairing failure in iOS12

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ make flash
 
 # Setup Code
 While pairing accessory and iOS devices, You must enter Setup Code at HOME App.
-The default setupt code is 
-## **`053-58-917`**
+The default setup code is 
+## **`053-58-197`**
 
 

--- a/src/pair_setup.c
+++ b/src/pair_setup.c
@@ -67,7 +67,7 @@ static int _subtlv_decrypt(enum hkdf_key_type htype,
         free(*subtlv);
         return -1;
     }
-    *subtlv_length = strlen((char*)*subtlv);
+    *subtlv_length = encrypted_tlv->length;
 
     return 0;
 }


### PR DESCRIPTION
Discussed in Issue #30.