### PR TITLE
IPv6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+#MacOS specific
+.DS_Store
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,9 +5,3 @@
 [submodule "examples/thermometer-hygrometer-dht22/components/esp32-dht22"]
 	path = examples/thermometer-hygrometer-dht22/components/esp32-dht22
 	url = https://github.com/younghyunjo/esp32-dht22.git
-[submodule "examples/tempHumiCO2/components/esp32-dht22"]
-	path = examples/tempHumiCO2/components/esp32-dht22
-	url = https://github.com/younghyunjo/esp32-dht22.git
-[submodule "examples/tempHumiCO2/components/ccs811-esp-idf"]
-	path = examples/tempHumiCO2/components/ccs811-esp-idf
-	url = https://github.com/gschorcht/ccs811-esp-idf.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,9 @@
 [submodule "examples/thermometer-hygrometer-dht22/components/esp32-dht22"]
 	path = examples/thermometer-hygrometer-dht22/components/esp32-dht22
 	url = https://github.com/younghyunjo/esp32-dht22.git
+[submodule "examples/tempHumiCO2/components/esp32-dht22"]
+	path = examples/tempHumiCO2/components/esp32-dht22
+	url = https://github.com/younghyunjo/esp32-dht22.git
+[submodule "examples/tempHumiCO2/components/ccs811-esp-idf"]
+	path = examples/tempHumiCO2/components/ccs811-esp-idf
+	url = https://github.com/gschorcht/ccs811-esp-idf.git

--- a/component.mk
+++ b/component.mk
@@ -80,6 +80,9 @@ WOLFSSL_SETTINGS =        \
     -DHAVE_CERTIFICATE_STATUS_REQUEST \
     -DCUSTOM_RAND_GENERATE_SEED=os_get_random
 
+MONGOOSE_SETTINGS =       \
+    -DMG_ENABLE_IPV6
+
 LWIP_INCDIRS = \
     -I$(IDF_PATH)/components/lwip/system \
     -I$(IDF_PATH)/components/lwip/include/lwip \
@@ -102,4 +105,5 @@ CFLAGS = \
     -Wno-old-style-declaration  \
     $(LWIP_INCDIRS)             \
     $(FREERTOS_INCDIRS)         \
-    $(WOLFSSL_SETTINGS)
+    $(WOLFSSL_SETTINGS)         \
+    $(MONGOOSE_SETTINGS)

--- a/examples/thermometer-hygrometer-dht22/main/main.cpp
+++ b/examples/thermometer-hygrometer-dht22/main/main.cpp
@@ -20,13 +20,13 @@
 #define TAG "SWITCH"
 
 #define ACCESSORY_NAME  "TEMP/HUMI"
-#define MANUFACTURER_NAME   "NikWest"
+#define MANUFACTURER_NAME   "YOUNGHYUN"
 #define MODEL_NAME  "ESP32_ACC"
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
 #if 1
-#define EXAMPLE_ESP_WIFI_SSID "nikwest"
-#define EXAMPLE_ESP_WIFI_PASS "eilemitweile!"
+#define EXAMPLE_ESP_WIFI_SSID "unibj"
+#define EXAMPLE_ESP_WIFI_PASS "12673063!"
 #endif
 #if 0
 #define EXAMPLE_ESP_WIFI_SSID "NO_RUN"
@@ -34,7 +34,7 @@
 #endif
 
 /* FIXME */
-static gpio_num_t DHT22_GPIO = GPIO_NUM_4;
+static gpio_num_t DHT22_GPIO = GPIO_NUM_22;
 
 static EventGroupHandle_t wifi_event_group;
 const int WIFI_GOT_IP_BIT = BIT0;

--- a/examples/thermometer-hygrometer-dht22/main/main.cpp
+++ b/examples/thermometer-hygrometer-dht22/main/main.cpp
@@ -26,7 +26,7 @@
 
 #if 1
 #define EXAMPLE_ESP_WIFI_SSID "unibj"
-#define EXAMPLE_ESP_WIFI_PASS "12673063!"
+#define EXAMPLE_ESP_WIFI_PASS "12673063"
 #endif
 #if 0
 #define EXAMPLE_ESP_WIFI_SSID "NO_RUN"

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -67,10 +67,13 @@ void* httpd_bind(int port, void* user_data) {
 
     struct mg_connection* nc = NULL;
     char port_string[8] = {0,};
-    sprintf(port_string, "%d", port);
+    #if MG_ENABLE_IPV6
+        sprintf(port_string, "[::]:%d", port);
+    #else
+        sprintf(port_string, "%d", port);
+    #endif
 
     xSemaphoreTake(_httpd_mutex, 0);
-
     nc = mg_bind(&_mgr, port_string, mg_ev_handler, user_data);
     if (nc == NULL) {
         printf("[ERR] mg_bind failed]n");


### PR DESCRIPTION
This will add support for IPv6. For me this solves the problem that in my mixed IPv4/IPv6 network I didn't have remote access. Essentially it adds the IPv6 option to mongoose and binds https also to the IPv6 interface. mDNS worked out of the box once the IPv6 stack has been created. See example code.